### PR TITLE
Patch to fix overwriting productivity gains from research

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -6,7 +6,6 @@ local gui_module = require("utility.gui_module")
 
 script.on_init(function()
     	storage.items = {}
-    	storage.productivityPercents = {}
     	product_cache.setupStorage()
 end)
 

--- a/control.lua
+++ b/control.lua
@@ -1,29 +1,18 @@
 -- Ensure global exists
-if global == nil then global = {} end
-if global.storage == nil then global.storage = {} end
+if storage == nil then storage = {} end
 
 local product_cache = require("utility.product_cache")
 local gui_module = require("utility.gui_module")
 
 script.on_init(function()
-    global.storage.items = {}
-    global.storage.productivityPercents = {}
-    product_cache.setupStorage()
-end)
-
--- On loading a saved game
-script.on_load(function()
-    if global.storage.items == nil then global.storage.items = {} end
-    if global.storage.productivityPercents == nil then global.storage.productivityPercents = {} end
-
-    if next(global.storage.productivityPercents) == nil then
-        global.storage.migration_needed = true
-    end
+    	storage.items = {}
+    	storage.productivityPercents = {}
+    	product_cache.setupStorage()
 end)
 
 -- When recipes could have changed or when we are initialized, create our local storage
 script.on_configuration_changed(function(event)
-    product_cache.setupStorage()
+   	product_cache.setupStorage()
 end)
 
 -- Events for toggling gui on and off

--- a/control.lua
+++ b/control.lua
@@ -3,30 +3,30 @@ local gui_module = require("utility.gui_module")
 
 -- When recipes could have changed or when we are initialized, create our local storage
 script.on_configuration_changed(function(event)
-   	product_cache.setupStorage()
+   product_cache.setupStorage()
 end)
 
 script.on_init(function()
-    storage.items = {}
-    product_cache.setupStorage()
+   storage.items = {}
+   product_cache.setupStorage()
 end)
 
 -- Events for toggling gui on and off
 script.on_event("toggle_progressive_productivity_gui", function(event)
-    local player = game.get_player(event.player_index)
-    gui_module.toggleProgressiveProductivityUI(player, event.tick)
+   local player = game.get_player(event.player_index)
+   gui_module.toggleProgressiveProductivityUI(player, event.tick)
 end)
 
 script.on_event(defines.events.on_lua_shortcut, function(event)
-    if event.prototype_name == "toggle_progressive_productivity_gui_shortcut" then
-        local player = game.get_player(event.player_index)
-        gui_module.toggleProgressiveProductivityUI(player, event.tick)
-    end
+   if event.prototype_name == "toggle_progressive_productivity_gui_shortcut" then
+      local player = game.get_player(event.player_index)
+      gui_module.toggleProgressiveProductivityUI(player, event.tick)
+   end
 end)
 
 script.on_event(defines.events.on_gui_closed, function(event)
-    if event.element and event.element.name == "progressive_productivty_list" then
-        local player = game.get_player(event.player_index)
-        gui_module.toggleProgressiveProductivityUI(player, event.tick)
-    end
+   if event.element and event.element.name == "progressive_productivty_list" then
+      local player = game.get_player(event.player_index)
+      gui_module.toggleProgressiveProductivityUI(player, event.tick)
+   end
 end)

--- a/control.lua
+++ b/control.lua
@@ -1,17 +1,14 @@
--- Ensure global exists
-if storage == nil then storage = {} end
-
 local product_cache = require("utility.product_cache")
 local gui_module = require("utility.gui_module")
-
-script.on_init(function()
-    	storage.items = {}
-    	product_cache.setupStorage()
-end)
 
 -- When recipes could have changed or when we are initialized, create our local storage
 script.on_configuration_changed(function(event)
    	product_cache.setupStorage()
+end)
+
+script.on_init(function()
+    storage.items = {}
+    product_cache.setupStorage()
 end)
 
 -- Events for toggling gui on and off

--- a/control.lua
+++ b/control.lua
@@ -1,12 +1,28 @@
+-- Ensure global exists
+if global == nil then global = {} end
+if global.storage == nil then global.storage = {} end
+
 local product_cache = require("utility.product_cache")
 local gui_module = require("utility.gui_module")
 
--- When recipes could have changed or when we are initialized, create our local storage
-script.on_configuration_changed(function(event)
+script.on_init(function()
+    global.storage.items = {}
+    global.storage.productivityPercents = {}
     product_cache.setupStorage()
 end)
 
-script.on_init(function(event)
+-- On loading a saved game
+script.on_load(function()
+    if global.storage.items == nil then global.storage.items = {} end
+    if global.storage.productivityPercents == nil then global.storage.productivityPercents = {} end
+
+    if next(global.storage.productivityPercents) == nil then
+        global.storage.migration_needed = true
+    end
+end)
+
+-- When recipes could have changed or when we are initialized, create our local storage
+script.on_configuration_changed(function(event)
     product_cache.setupStorage()
 end)
 

--- a/utility/product_cache.lua
+++ b/utility/product_cache.lua
@@ -81,45 +81,44 @@ end
 
 production_cache.on_production_statistics_may_have_changed(function()
     for force_name, production_values in pairs(production_cache.production_statistics) do
-            local force = game.forces[force_name]
-            if not force then goto continue_force_loop end
+        local force = game.forces[force_name]
+        if not force then goto continue_force_loop end
 
-            setupStorage()
+        setupStorage()
 
-            -- STEP 1: Get the base productivity from vanilla/other mod research.
-            local research_bonuses = get_research_bonuses_by_recipe(force)
+        -- STEP 1: Get the base productivity from vanilla/other mod research.
+        local research_bonuses = get_research_bonuses_by_recipe(force)
 
-            -- STEP 2: Calculate what this mod's bonus *should* be for each recipe.
-            local should_be_mod_bonuses = {}
-            for item_name, production_count in pairs(production_values) do
-                if production_count > 0 then
-                    local item_data = storage.items[item_name]
-                    if item_data then
-                        local level = calculateProductivityLevel(item_data.type, production_count)
-                        local mod_bonus = calculateProductivityAmount(item_data.type, level)
-                        for _, recipe_name in pairs(item_data.recipes) do
-                            should_be_mod_bonuses[recipe_name] = math.max(should_be_mod_bonuses[recipe_name] or 0, mod_bonus)
-                        end
+        -- STEP 2: Calculate what this mod's bonus *should* be for each recipe.
+        local should_be_mod_bonuses = {}
+        for item_name, production_count in pairs(production_values) do
+            if production_count > 0 then
+                local item_data = storage.items[item_name]
+                if item_data then
+                    local level = calculateProductivityLevel(item_data.type, production_count)
+                    local mod_bonus = calculateProductivityAmount(item_data.type, level)
+                    for _, recipe_name in pairs(item_data.recipes) do
+                        should_be_mod_bonuses[recipe_name] = math.max(should_be_mod_bonuses[recipe_name] or 0, mod_bonus)
                     end
                 end
             end
+        end
 
 	    -- STEP 3: Apply the calculations
-            for recipe_name, recipe in pairs(force.recipes) do
-                if recipe.valid and recipe.enabled then
-		    local research_bonus = research_bonuses[recipe_name] or 0
-                    local mod_bonus = should_be_mod_bonuses[recipe_name] or 0
-		    local prod_bonus = research_bonus + mod_bonus
-		    if not are_doubles_equal(recipe.productivity_bonus, prod_bonus) then
-         
-			local display_item_name = {"?", {"item-name."..recipe_name}, {"fluid-name."..recipe_name}, {"entity-name."..recipe_name}, recipe_name}
-			-- This is because Factorio internally floors productivity_bonus to 2 decimal places. This causes 1.05 to (which is a float equal to 1.0499999523162841796875) to round to 1.04, causing many notifications
+        for recipe_name, recipe in pairs(force.recipes) do
+            if recipe.valid and recipe.enabled then
+				local research_bonus = research_bonuses[recipe_name] or 0
+                local mod_bonus = should_be_mod_bonuses[recipe_name] or 0
+				local prod_bonus = research_bonus + mod_bonus
+		    	if not are_doubles_equal(recipe.productivity_bonus, prod_bonus) then
+					local display_item_name = {"?", {"item-name."..recipe_name}, {"fluid-name."..recipe_name}, {"entity-name."..recipe_name}, recipe_name}
+					-- This is because Factorio internally floors productivity_bonus to 2 decimal places. This causes 1.05 to (which is a float equal to 1.0499999523162841796875) to round to 1.04, causing many notifications
                		game.print({"", {"mod-message.progressive-productivity-progressed", display_item_name, (prod_bonus * 100)}})
-			prod_bonus = prod_bonus + 0.00001
-			recipe.productivity_bonus = prod_bonus
-		    end
-                end
+					prod_bonus = prod_bonus + 0.00001
+					recipe.productivity_bonus = prod_bonus
+		    	end
             end
+        end
 	    ::continue_force_loop::
     end
 end)

--- a/utility/product_cache.lua
+++ b/utility/product_cache.lua
@@ -70,11 +70,12 @@ function get_research_bonuses_by_recipe(force)
 				if effect.type == "change-recipe-productivity" then
 					local recipe_name = effect.recipe
 					local change_per_level = effect.change or 0
+					-- current tech.level is always one ahead of researched level
 					local total_bonus = change_per_level * (technology.level - 1)
 					recipe_bonuses[recipe_name] = (recipe_bonuses[recipe_name] or 0) + total_bonus
 				end	
 			end
-			-- DEBUG game.print(string.format("%s, %.2f", technology.name, technology.level * 10))
+			-- DEBUG game.print(string.format("%s, %.2f", technology.name, (technology.level -1) * 10))
 		end
 	end
 	return recipe_bonuses

--- a/utility/product_cache.lua
+++ b/utility/product_cache.lua
@@ -1,13 +1,12 @@
 local product_cache = {}
 local settings_cache = require("utility.settings_cache")
 local production_cache = require("utility.production_cache")
--- This function populates the storage items table with a map of items to recipies.
+
 function setupStorage()
-	if global.storage.items == nil then global.storage.items = {} end
-	if global.storage.productivityPercents == nil then global.storage.productivityPercents = {} end
-	-- Get our list of item -> recipe
-	playerForce = game.forces['player']
-	recipes = playerForce.recipes
+	local new_items_map = {}
+	local playerForce = game.forces['player']
+	local recipes = playerForce.recipes
+
 	for _, recipe in pairs(recipes) do
 		if recipe.products == nil or recipe.name:match"empty.*barrel" or recipe.name:match".+barrel" then
 			goto continue
@@ -15,27 +14,28 @@ function setupStorage()
 		if recipe.name:match".*recycling" then
 			goto continue
 		end
-		if settings.startup['progressive-productivity-intermediates-only'].value and prototypes.recipe[recipe.name].allowed_effects["productivity"] == false then
+		-- Use settings_cache for consistency
+		if settings_cache.settings.intermediates_only and prototypes.recipe[recipe.name].allowed_effects["productivity"] == false then
 			goto continue
 		end
 		for _, product in pairs(recipe.products) do
-			if global.storage.items[product.name] == nil then
-				global.storage.items[product.name] = {
+			if new_items_map[product.name] == nil then
+				new_items_map[product.name] = {
 					recipes = {},
 					type = product.type
 				}
 			end
-			table.insert(global.storage.items[product.name]["recipes"], recipe.name)
+			table.insert(new_items_map[product.name]["recipes"], recipe.name)
 		end
 		::continue::
 	end
-	
+	storage.items = new_items_map
 end
 product_cache.setupStorage = setupStorage
+
 ---@param type string
 ---@param production_amount number
 function calculateProductivityLevel(type, production_amount)
-	-- Get the number of an item / fluid produced-- Get the amount of an item or fluid produced
 	local product_settings = settings_cache.settings[type] --[[@as ProductSettings]]
 	local cost = product_settings.cost_base
 	local level = 0
@@ -46,122 +46,81 @@ function calculateProductivityLevel(type, production_amount)
 	return level
 end
 product_cache.calculateProductivityLevel = calculateProductivityLevel
+
 ---@param type string
 ---@param level int
 function calculateProductivityAmount(type, level)
-	prod_mult = settings_cache.settings[type].productivity_bonus
+	local prod_mult = settings_cache.settings[type].productivity_bonus
 	return level * prod_mult
 end
 product_cache.calculateProductivityAmount = calculateProductivityAmount
-	local function are_doubles_equal(a, b, epsilon)
-	epsilon = epsilon or 1e-4  -- Default epsilon value
+
+local function are_doubles_equal(a, b, epsilon)
+	epsilon = epsilon or 1e-4
 	return math.abs(a - b) < epsilon
 end
 
+-- This function is a utility needed for first run after load.
+function get_research_bonuses_by_recipe(force)
+    local recipe_bonuses = {}
+    for tech_name, technology in pairs(force.technologies) do
+        if technology.level > 1 and string.match(technology.name, "-productivity") then
+            for _, effect in pairs(technology.prototype.effects) do
+                if effect.type == "change-recipe-productivity" then
+                    local recipe_name = effect.recipe
+                    local change_per_level = effect.change or 0
+                    local total_bonus = change_per_level * (technology.level - 1)
+                    recipe_bonuses[recipe_name] = (recipe_bonuses[recipe_name] or 0) + total_bonus
+                end
+            end
+	    -- DEBUG game.print(string.format("%s, %.2f", technology.name, technology.level * 10))
+        end
+    end
+    return recipe_bonuses
+end
+
 production_cache.on_production_statistics_may_have_changed(function()
-	if global.storage.first_start then
-        	global.storage.first_start = nil
-        	local playerForce = game.forces['player']
-		
-		-- check if modded first, if its modded global.storage.items should be there. Affects migration.
- 		local is_unmodded_save = (global.storage.items == nil or next(global.storage.items) == nil)
-		if is_unmodded_save then game.print("Progressive Productivity: Starting initial calculations...")
-		else game.print("Progressive Productivity: Starting migration") end
-        	setupStorage()
-		global.storage.productivityPercents = {} -- must be clear
-
-        	-- STEP 1: Calculate what the current production values for each recipe.
-        	local should_be_mod_bonuses = {}
-        	local current_production_values = {}
-        	for _, surface in pairs(game.surfaces) do
-            		local item_stats = playerForce.get_item_production_statistics(surface)
-            		local fluid_stats = playerForce.get_fluid_production_statistics(surface)
-            		for item_name, _ in pairs(global.storage.items) do
-                		current_production_values[item_name] = (current_production_values[item_name] or 0)
-                                                    + item_stats.get_input_count(item_name)
-                                                    + fluid_stats.get_input_count(item_name)
-            		end
-       		end
-		-- STEP 2: Calculate what the mod bonus *should* be for each recipe attached to that item (eg multiple fuel recipes).
-        	for item_name, production_count in pairs(current_production_values) do
-            		if production_count > 0 then
-                		local item_data = global.storage.items[item_name]
-                		if item_data then
-                    			local level = calculateProductivityLevel(item_data.type, production_count)
-                    			local mod_bonus = calculateProductivityAmount(item_data.type, level)
-                    			for _, recipe_name in pairs(item_data.recipes) do
-                        			should_be_mod_bonuses[recipe_name] = math.max(should_be_mod_bonuses[recipe_name] or 0, mod_bonus)
-                    			end
-                		end
-            		end
-        	end
-		-- STEP 3: Apply bonuses depending on migration conditions.
-        	for recipe_name, recipe in pairs(playerForce.recipes) do
-            		if recipe.valid and recipe.enabled then
-                		local new_bonus = should_be_mod_bonuses[recipe_name] or 0
-				if is_unmodded_save then
-					-- add the bonus to unmodded
-                    			recipe.productivity_bonus = (recipe.productivity_bonus or 0) + new_bonus
-                		else
-					-- take the max when migrating (preserves other productivity sources)
-					recipe.productivity_bonus = math.max(new_bonus, recipe.productivity_bonus or 0)
- 				end
-                             	if new_bonus > 0 then
-                    			global.storage.productivityPercents[recipe_name] = new_bonus
-                		end
-            		end
-        	end
-        	return
-    	end
-
     for force_name, production_values in pairs(production_cache.production_statistics) do
-        local force = game.forces[force_name]
-        if not force then goto continue_force_loop end -- Safety check for cases like force being destroyed
+            local force = game.forces[force_name]
+            if not force then goto continue_force_loop end
 
-        local processed_recipes = {} -- Stores the highest calculated `prod_bonus` for each recipe
+            setupStorage()
 
-        for item_name, production_count in pairs(production_values) do
-            if production_count > 0 then
-                local item_data = global.storage.items[item_name]
-                if not item_data then
-                    -- This item might be produced but not tracked by your setupStorage (e.g., filtered out)
-                    goto continue_item_loop
+            -- STEP 1: Get the base productivity from vanilla/other mod research.
+            local research_bonuses = get_research_bonuses_by_recipe(force)
+
+            -- STEP 2: Calculate what this mod's bonus *should* be for each recipe.
+            local should_be_mod_bonuses = {}
+            for item_name, production_count in pairs(production_values) do
+                if production_count > 0 then
+                    local item_data = storage.items[item_name]
+                    if item_data then
+                        local level = calculateProductivityLevel(item_data.type, production_count)
+                        local mod_bonus = calculateProductivityAmount(item_data.type, level)
+                        for _, recipe_name in pairs(item_data.recipes) do
+                            should_be_mod_bonuses[recipe_name] = math.max(should_be_mod_bonuses[recipe_name] or 0, mod_bonus)
+                        end
+                    end
                 end
+            end
 
-                local level = calculateProductivityLevel(item_data.type, production_count)
-                local mod_calculated_prod_bonus = calculateProductivityAmount(item_data.type, level)
-
-                for _, recipe_name in pairs(item_data.recipes) do
-                    -- Ensure `processed_recipes` stores the *maximum* bonus from any of its products
-                    processed_recipes[recipe_name] = math.max(processed_recipes[recipe_name] or 0, mod_calculated_prod_bonus)
+	    -- STEP 3: Apply the calculations
+            for recipe_name, recipe in pairs(force.recipes) do
+                if recipe.valid and recipe.enabled then
+		    local research_bonus = research_bonuses[recipe_name] or 0
+                    local mod_bonus = should_be_mod_bonuses[recipe_name] or 0
+		    local prod_bonus = research_bonus + mod_bonus
+		    if not are_doubles_equal(recipe.productivity_bonus, prod_bonus) then
+         
+			local display_item_name = {"?", {"item-name."..recipe_name}, {"fluid-name."..recipe_name}, {"entity-name."..recipe_name}, recipe_name}
+			-- This is because Factorio internally floors productivity_bonus to 2 decimal places. This causes 1.05 to (which is a float equal to 1.0499999523162841796875) to round to 1.04, causing many notifications
+               		game.print({"", {"mod-message.progressive-productivity-progressed", display_item_name, (prod_bonus * 100)}})
+			prod_bonus = prod_bonus + 0.00001
+			recipe.productivity_bonus = prod_bonus
+		    end
                 end
             end
-            ::continue_item_loop::
-        end
-
-        for recipe_name, new_mod_prod_bonus_target in pairs(processed_recipes) do
-            local recipe = force.recipes[recipe_name]
-            if not recipe or not recipe.valid or not recipe.enabled then
-                goto continue_recipe_loop -- Skip invalid/disabled recipes
-            end
-
-            local current_total_recipe_bonus = recipe.productivity_bonus or 0
-            local mod_previous_bonus_applied = global.storage.productivityPercents[recipe_name] or 0
-            local base_productivity_from_research = current_total_recipe_bonus - mod_previous_bonus_applied
-            local calculated_total_bonus = base_productivity_from_research + new_mod_prod_bonus_target
-
-            -- Compare with a small epsilon to avoid unnecessary updates and notifications
-            -- due to floating-point precision issues in Factorio's internal API.
-            if not are_doubles_equal(current_total_recipe_bonus, calculated_total_bonus) then
-                local display_item_name = {"?", {"item-name."..recipe_name}, {"fluid-name."..recipe_name}, {"entity-name."..recipe_name}, recipe_name}
-                local display_value = string.format("%.2f", calculated_total_bonus * 100)
- 		game.print({"", {"mod-message.progressive-productivity-progressed", display_item_name, display_value}})
-                recipe.productivity_bonus = calculated_total_bonus
-                global.storage.productivityPercents[recipe_name] = new_mod_prod_bonus_target
-            end
-            ::continue_recipe_loop::
-        end
-        ::continue_force_loop::
+	    ::continue_force_loop::
     end
 end)
 

--- a/utility/product_cache.lua
+++ b/utility/product_cache.lua
@@ -1,68 +1,110 @@
 local product_cache = {}
-
 local settings_cache = require("utility.settings_cache")
 local production_cache = require("utility.production_cache")
-
--- This function creates a map of item to recipe 
+-- This function creates a map of item to recipe
 function setupStorage()
-    storage.items = {}
-    storage.productivityPercents = {}
-    -- Get our list of item -> recipe
-    playerForce = game.forces['player']
-    recipes = playerForce.recipes
-    for _, recipe in pairs(recipes) do
-        if recipe.products == nil or recipe.name:match"empty.*barrel" or recipe.name:match".+barrel" then 
-            goto continue
-        end
-        if recipe.name:match".*recycling" then
-            goto continue
-        end
-        if settings.startup['progressive-productivity-intermediates-only'].value and prototypes.recipe[recipe.name].allowed_effects["productivity"] == false then
-            goto continue
-        end
-        for _, product in pairs(recipe.products) do
-            if storage.items[product.name] == nil then
-                storage.items[product.name] = {
-                    recipes = {},
-                    type = product.type
-                }
-            end
-            table.insert(storage.items[product.name]["recipes"], recipe.name)
-        end
-        ::continue::
-    end
+	if storage.items == nil then storage.items = {} end
+	if storage.productivityPercents == nil then storage.productivityPercents = {} end
+	-- Get our list of item -> recipe
+	playerForce = game.forces['player']
+	recipes = playerForce.recipes
+	for _, recipe in pairs(recipes) do
+		if recipe.products == nil or recipe.name:match"empty.*barrel" or recipe.name:match".+barrel" then
+			goto continue
+		end
+		if recipe.name:match".*recycling" then
+			goto continue
+		end
+		if settings.startup['progressive-productivity-intermediates-only'].value and prototypes.recipe[recipe.name].allowed_effects["productivity"] == false then
+			goto continue
+		end
+		for _, product in pairs(recipe.products) do
+			if storage.items[product.name] == nil then
+				storage.items[product.name] = {
+					recipes = {},
+					type = product.type
+				}
+			end
+			table.insert(storage.items[product.name]["recipes"], recipe.name)
+		end
+		::continue::
+	end
+	
 end
 product_cache.setupStorage = setupStorage
-
 ---@param type string
 ---@param production_amount number
 function calculateProductivityLevel(type, production_amount)
-    -- Get the number of an item / fluid produced-- Get the amount of an item or fluid produced
-    local product_settings = settings_cache.settings[type] --[[@as ProductSettings]]
-    local cost = product_settings.cost_base
-    local level = 0
-    while production_amount >= cost do
-        level = level + 1
-        cost = math.ceil(cost * product_settings.cost_multiplier)
-    end
-    return level
+	-- Get the number of an item / fluid produced-- Get the amount of an item or fluid produced
+	local product_settings = settings_cache.settings[type] --[[@as ProductSettings]]
+	local cost = product_settings.cost_base
+	local level = 0
+	while production_amount >= cost do
+		level = level + 1
+		cost = math.ceil(cost * product_settings.cost_multiplier)
+	end
+	return level
 end
 product_cache.calculateProductivityLevel = calculateProductivityLevel
-
 ---@param type string
 ---@param level int
 function calculateProductivityAmount(type, level)
-    prod_mult = settings_cache.settings[type].productivity_bonus
-    return level * prod_mult
+	prod_mult = settings_cache.settings[type].productivity_bonus
+	return level * prod_mult
 end
 product_cache.calculateProductivityAmount = calculateProductivityAmount
-
-local function are_doubles_equal(a, b, epsilon)
-    epsilon = epsilon or 1e-4  -- Default epsilon value
-    return math.abs(a - b) < epsilon
+	local function are_doubles_equal(a, b, epsilon)
+	epsilon = epsilon or 1e-4  -- Default epsilon value
+	return math.abs(a - b) < epsilon
 end
 
 production_cache.on_production_statistics_may_have_changed(function()
+	if global.storage.migration_needed then
+        	global.storage.migration_needed = nil
+        	game.print("Progressive Productivity: Running scheduled migration...")
+
+        	local playerForce = game.forces['player']
+        	setupStorage()
+        	-- STEP 1: Calculate what the bonus *should* be for each recipe right now.
+        	local should_be_mod_bonuses = {}
+        	local current_production_values = {}
+        	for _, surface in pairs(game.surfaces) do
+            		local item_stats = playerForce.get_item_production_statistics(surface)
+            		local fluid_stats = playerForce.get_fluid_production_statistics(surface)
+            		for item_name, _ in pairs(global.storage.items) do
+                		current_production_values[item_name] = (current_production_values[item_name] or 0)
+                                                    + item_stats.get_input_count(item_name)
+                                                    + fluid_stats.get_input_count(item_name)
+            		end
+       		end
+        	for item_name, production_count in pairs(current_production_values) do
+            		if production_count > 0 then
+                		local item_data = global.storage.items[item_name]
+                		if item_data then
+                    			local level = calculateProductivityLevel(item_data.type, production_count)
+                    			local mod_bonus = calculateProductivityAmount(item_data.type, level)
+                    			for _, recipe_name in pairs(item_data.recipes) do
+                        			should_be_mod_bonuses[recipe_name] = math.max(should_be_mod_bonuses[recipe_name] or 0, mod_bonus)
+                    			end
+                		end
+            		end
+        	end
+		storage.productivityPercents = {} -- Clear the history for a fresh start.
+        	for recipe_name, recipe in pairs(playerForce.recipes) do
+            		if recipe.valid and recipe.enabled then
+                		local new_bonus = should_be_mod_bonuses[recipe_name] or 0
+                		recipe.productivity_bonus = new_bonus
+
+                             	if new_bonus > 0 then
+                    			storage.productivityPercents[recipe_name] = new_bonus
+                		end
+            		end
+        	end
+
+        	game.print("Progressive Productivity: Migration complete. All recipe bonuses have been reset.")
+        	return
+    	end
+
     for force_name, production_values in pairs(production_cache.production_statistics) do
         local force = game.forces[force_name]
         if not force then goto continue_force_loop end -- Safety check for cases like force being destroyed
@@ -113,6 +155,5 @@ production_cache.on_production_statistics_may_have_changed(function()
         ::continue_force_loop::
     end
 end)
-
 
 return product_cache

--- a/utility/product_cache.lua
+++ b/utility/product_cache.lua
@@ -61,7 +61,7 @@ local function are_doubles_equal(a, b, epsilon)
 	return math.abs(a - b) < epsilon
 end
 
--- This function is a utility needed for first run after load.
+-- This function calculates the research bonuses.
 function get_research_bonuses_by_recipe(force)
 	local recipe_bonuses = {}
 	for tech_name, technology in pairs(force.technologies) do
@@ -89,7 +89,8 @@ production_cache.on_production_statistics_may_have_changed(function()
 
 		-- STEP 1: Get the base productivity from vanilla/other mod research.
 		local research_bonuses = get_research_bonuses_by_recipe(force)
-
+		-- TODO: Extract this from on_production_statistics and put it in its own cache (storage.research) and update it on_research_completed to save some UPS
+			
 		-- STEP 2: Calculate what this mod's bonus *should* be for each recipe.
 		local should_be_mod_bonuses = {}
 		for item_name, production_count in pairs(production_values) do


### PR DESCRIPTION
Fixed the overwriting issue by storing a cache of past percentage gains. Fixed a follow up issue with migrating to this version: The updated cache was zeroed out leading to a doubling of the bonus. Since this mod previously overwrote productivity, it just zeroes all mod affected production before applying the 'new' bonus.

Main changes are to:
product_cache.lua - on_production_statistics_may_have_changed function: now properly migrates if flag is set
product_cache.lua - on_production_statistics_may_have_changed function: bonuses from research are kept and are no longer overwritten.
control.lua - added onload func to set migration flag.

Works with initial testing.

Only thing you might want to change is the decimals shown.